### PR TITLE
Fix use of deprecated/removed constant WATCHDOG_INFO

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -178,7 +178,7 @@ class Consumer {
       $readyMessage = "RabbitMQ worker ready to receive an unlimited number of messages.";
       $readyArgs = [];
     }
-    $this->logger->debug($readyMessage, $readyArgs, WATCHDOG_INFO);
+    $this->logger->debug($readyMessage, $readyArgs);
   }
 
   /**


### PR DESCRIPTION
[info] Use of undefined constant WATCHDOG_INFO - assumed 'WATCHDOG_INFO' Consumer.php:181 [0.429999999999999993 sec, 9.97000000000000064 MB]